### PR TITLE
Update README.md to reflect current version of processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Consult the [LX Studio API reference &rarr;](http://lx.studio/api/)
 
 ### Configure Your Runtime ###
 
-Processing 4.0 beta 8 runs on [Eclipse Temurin 17 (17.0.2+8)](https://adoptium.net/). It is highly recommend to use this JDK for consistency.
+Processing 4.0.1 runs on [Eclipse Temurin 17 (17.0.2+8)](https://adoptium.net/). It is highly recommend to use this JDK for consistency.
 
 The core Processing libraries are not available in Maven central. The first time you setup your project, you must manually run `mvn validate` a single time to install the Processing runtime libraries into your local Maven repository. This is a one-time only step.
 
-Running the project requires passing `-Djava.library.path=lib/processing-4.0b8/native` explicitly to the `java` command. Note that `native` is a symlink within the `processing-4.0b8` folder which should be pointed at the appropriate target platform folder.
+Running the project requires passing `-Djava.library.path=lib/processing-4.0.1/native` explicitly to the `java` command. Note that `native` is a symlink within the `processing-4.0.1` folder which should be pointed at the appropriate target platform folder.
 
 This is pre-configured in the Eclipse launch configuration `LXStudioApp.launch`
 
 If you change platforms, update the symlink using one of the following:
 ```
-$ cd lib/processing-4.0b8
+$ cd lib/processing-4.0.1
 $ ln -hsf linux-aarch64 native
 $ ln -hsf linux-amd64 native
 $ ln -hsf linux-arm native


### PR DESCRIPTION
The readme has instructions for setting up with processing 4.0.b8 but the repo has all references to 4.0.1, so this just fixes the readme to have the correct processing version